### PR TITLE
Removes Annotation.duration

### DIFF
--- a/gen-go/zipkin/constants.go
+++ b/gen-go/zipkin/constants.go
@@ -19,6 +19,10 @@ const CLIENT_SEND = "cs"
 const CLIENT_RECV = "cr"
 const SERVER_SEND = "ss"
 const SERVER_RECV = "sr"
+const WIRE_SEND = "ws"
+const WIRE_RECV = "wr"
+const CLIENT_ADDR = "ca"
+const SERVER_ADDR = "sa"
 
 func init() {
 }

--- a/gen-go/zipkin/ttypes.go
+++ b/gen-go/zipkin/ttypes.go
@@ -231,7 +231,6 @@ type Annotation struct {
 	Timestamp int64     `thrift:"timestamp,1" json:"timestamp"`
 	Value     string    `thrift:"value,2" json:"value"`
 	Host      *Endpoint `thrift:"host,3" json:"host"`
-	Duration  *int32    `thrift:"duration,4" json:"duration"`
 }
 
 func NewAnnotation() *Annotation {
@@ -254,21 +253,8 @@ func (p *Annotation) GetHost() *Endpoint {
 	}
 	return p.Host
 }
-
-var Annotation_Duration_DEFAULT int32
-
-func (p *Annotation) GetDuration() int32 {
-	if !p.IsSetDuration() {
-		return Annotation_Duration_DEFAULT
-	}
-	return *p.Duration
-}
 func (p *Annotation) IsSetHost() bool {
 	return p.Host != nil
-}
-
-func (p *Annotation) IsSetDuration() bool {
-	return p.Duration != nil
 }
 
 func (p *Annotation) Read(iprot thrift.TProtocol) error {
@@ -294,10 +280,6 @@ func (p *Annotation) Read(iprot thrift.TProtocol) error {
 			}
 		case 3:
 			if err := p.ReadField3(iprot); err != nil {
-				return err
-			}
-		case 4:
-			if err := p.ReadField4(iprot); err != nil {
 				return err
 			}
 		default:
@@ -341,15 +323,6 @@ func (p *Annotation) ReadField3(iprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *Annotation) ReadField4(iprot thrift.TProtocol) error {
-	if v, err := iprot.ReadI32(); err != nil {
-		return fmt.Errorf("error reading field 4: %s", err)
-	} else {
-		p.Duration = &v
-	}
-	return nil
-}
-
 func (p *Annotation) Write(oprot thrift.TProtocol) error {
 	if err := oprot.WriteStructBegin("Annotation"); err != nil {
 		return fmt.Errorf("%T write struct begin error: %s", p, err)
@@ -361,9 +334,6 @@ func (p *Annotation) Write(oprot thrift.TProtocol) error {
 		return err
 	}
 	if err := p.writeField3(oprot); err != nil {
-		return err
-	}
-	if err := p.writeField4(oprot); err != nil {
 		return err
 	}
 	if err := oprot.WriteFieldStop(); err != nil {
@@ -411,21 +381,6 @@ func (p *Annotation) writeField3(oprot thrift.TProtocol) (err error) {
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
 			return fmt.Errorf("%T write field end error 3:host: %s", p, err)
-		}
-	}
-	return err
-}
-
-func (p *Annotation) writeField4(oprot thrift.TProtocol) (err error) {
-	if p.IsSetDuration() {
-		if err := oprot.WriteFieldBegin("duration", thrift.I32, 4); err != nil {
-			return fmt.Errorf("%T write field begin error 4:duration: %s", p, err)
-		}
-		if err := oprot.WriteI32(int32(*p.Duration)); err != nil {
-			return fmt.Errorf("%T.duration (4) field write error: %s", p, err)
-		}
-		if err := oprot.WriteFieldEnd(); err != nil {
-			return fmt.Errorf("%T write field end error 4:duration: %s", p, err)
 		}
 	}
 	return err

--- a/trace.go
+++ b/trace.go
@@ -141,36 +141,31 @@ func NewTraceForHTTPHeader(traceName string, h http.Header, collectors []SpanCol
 	return NewTraceForIDs(traceName, traceID, spanID, parentSpanID, collectors)
 }
 
-func NewTimestampAnnotation(value string, t time.Time, d time.Duration) *zipkin.Annotation {
+func NewTimestampAnnotation(value string, t time.Time) *zipkin.Annotation {
 	if t.IsZero() {
 		t = time.Now()
-	}
-	var duration *int32
-	if d != 0 {
-		duration = thrift.Int32Ptr(int32(d / time.Microsecond))
 	}
 
 	return &zipkin.Annotation{
 		Timestamp: t.UnixNano() / 1e3,
-		Value:     value,
-		Duration:  duration,
+		Value:     value
 	}
 }
 
 func ClientSendAnnotation(t time.Time) *zipkin.Annotation {
-	return NewTimestampAnnotation(zipkin.CLIENT_SEND, t, 0)
+	return NewTimestampAnnotation(zipkin.CLIENT_SEND, t)
 }
 
 func ClientRecvAnnotation(t time.Time) *zipkin.Annotation {
-	return NewTimestampAnnotation(zipkin.CLIENT_RECV, t, 0)
+	return NewTimestampAnnotation(zipkin.CLIENT_RECV, t)
 }
 
 func ServerSendAnnotation(t time.Time) *zipkin.Annotation {
-	return NewTimestampAnnotation(zipkin.SERVER_SEND, t, 0)
+	return NewTimestampAnnotation(zipkin.SERVER_SEND, t)
 }
 
 func ServerRecvAnnotation(t time.Time) *zipkin.Annotation {
-	return NewTimestampAnnotation(zipkin.SERVER_RECV, t, 0)
+	return NewTimestampAnnotation(zipkin.SERVER_RECV, t)
 }
 
 func NewStringAnnotation(key string, value string) *zipkin.BinaryAnnotation {

--- a/zipkin.thrift
+++ b/zipkin.thrift
@@ -14,13 +14,18 @@
 namespace java com.twitter.zipkin.gen
 namespace rb Zipkin
 
-//************** Collection related structs **************
-
-// these are the annotations we always expect to find in a span
+//************** Common annotation values **************
 const string CLIENT_SEND = "cs"
 const string CLIENT_RECV = "cr"
 const string SERVER_SEND = "ss"
 const string SERVER_RECV = "sr"
+const string WIRE_SEND = "ws"
+const string WIRE_RECV = "wr"
+
+//************** Common binary annotation keys **************
+const string CLIENT_ADDR = "ca"
+const string SERVER_ADDR = "sa"
+
 
 // this represents a host and port in a network
 struct Endpoint {
@@ -34,7 +39,7 @@ struct Annotation {
   1: i64 timestamp                 // microseconds from epoch
   2: string value                  // what happened at the timestamp?
   3: optional Endpoint host        // host this happened on
-  4: optional i32 duration         // how long did the operation take? microseconds
+  // 4: optional i32 OBSOLETE_duration         // how long did the operation take? microseconds
 }
 
 enum AnnotationType { BOOL, BYTES, I16, I32, I64, DOUBLE, STRING }


### PR DESCRIPTION
This updates to the latest zipkin thrift, including removing the
troublesome annotation.duration field.

See https://github.com/openzipkin/zipkin/pull/717
